### PR TITLE
Fix/modal scrolling

### DIFF
--- a/src/components/Modal/Modal.tsx
+++ b/src/components/Modal/Modal.tsx
@@ -80,24 +80,26 @@ export const Modal = (props: ModalProps) => {
 
   return (
     <DialogPrimitive.Root {...modalProps}>
-      <DialogPrimitive.Overlay className="st-react-modal--overlay" />
-      <ModalContent className={className}>
-        <div className="st-react-modal--header">
-          <div className="st-react-modal--header--title-row">
-            <ModalTitle asChild>
-              <div className="st-react-modal--header--text st-typography-header">
-                {title}
-              </div>
-            </ModalTitle>
-            <DialogPrimitive.Close asChild>
-              <Button variant="icon">
-                <IconClose />
-              </Button>
-            </DialogPrimitive.Close>
+      <DialogPrimitive.Overlay className="st-react-modal--overlay">
+        <ModalContent className={className}>
+          <div className="st-react-modal--header">
+            <div className="st-react-modal--header--title-row">
+              <ModalTitle asChild>
+                <div className="st-react-modal--header--text st-typography-header">
+                  {title}
+                </div>
+              </ModalTitle>
+              <DialogPrimitive.Close asChild>
+                <Button variant="icon">
+                  <IconClose />
+                </Button>
+              </DialogPrimitive.Close>
+            </div>
           </div>
-        </div>
-        {children}
-      </ModalContent>
+          {children}
+        </ModalContent>
+      </DialogPrimitive.Overlay>
+
       {trigger && <ModalTrigger asChild>{trigger}</ModalTrigger>}
     </DialogPrimitive.Root>
   );

--- a/src/stories/Dropdown.stories.tsx
+++ b/src/stories/Dropdown.stories.tsx
@@ -10,7 +10,7 @@ export default {
 } as ComponentMeta<typeof Dropdown>;
 
 const Template: ComponentStory<typeof Dropdown> = (args) => (
-  <Dropdown {...args} onChange={action('changed')} />
+  <Dropdown {...args} onChange={action("changed")} />
 );
 
 export const Default = Template.bind({});
@@ -29,9 +29,18 @@ Default.args = {
 
 export const LongList = Template.bind({});
 const longListItems = [];
-for (let i = 0; i < 100; i++)
+for (let i = 0; i < 100; i++) {
   longListItems.push({ label: `Label ${i}`, value: i });
+}
 LongList.args = {
+  options: longListItems,
+  label: "Dropdown Label",
+  labelPosition: "top",
+};
+
+export const MaxHeight = Template.bind({});
+MaxHeight.args = {
+  maxMenuHeight: 72,
   options: longListItems,
   label: "Dropdown Label",
   labelPosition: "top",

--- a/src/stories/Modal.stories.tsx
+++ b/src/stories/Modal.stories.tsx
@@ -8,7 +8,7 @@ import {
   ModalBody,
   ModalDescription,
 } from "components/Modal";
-import { Button } from "index";
+import { Button, Dropdown } from "index";
 
 export default {
   title: "Molecules/Modal",
@@ -41,6 +41,53 @@ Controlled.args = {
         <Button>Begin</Button>
       </ModalActionRow>
     </>
+  ),
+};
+
+export const WithScrollingContent = Template.bind({});
+WithScrollingContent.parameters = { docs: { disable: true } }; // disable docs for this modal since it will always be open and will interfere with doc viewing
+WithScrollingContent.args = {
+  title: "Modal Title",
+  open: true,
+  onOpenChange: action("open changed"),
+  children: (
+    <div style={{ maxHeight: "400px", overflow: "auto" }}>
+      <ModalBody>
+        <ModalDescription>
+          Somewhere, something incredible is waiting to be known.
+        </ModalDescription>
+        {/* @ts-ignore */}
+        <Dropdown
+          maxMenuHeight={100}
+          onChange={() => {}}
+          label="Label"
+          labelPosition="top"
+          options={[
+            { label: "Label 1", value: 1 },
+            { label: "Label 2", value: 2 },
+            { label: "Label 3", value: 3 },
+            { label: "Label 4", value: 4 },
+            { label: "Label 5", value: 5 },
+            { label: "Label 6", value: 6 },
+            { label: "Label 6", value: 6 },
+            { label: "Label 6", value: 6 },
+            { label: "Label 6", value: 6 },
+            { label: "Label 6", value: 6 },
+            { label: "Label 6", value: 6 },
+            { label: "Label 6", value: 6 },
+            { label: "Label 6", value: 6 },
+          ]}
+        />
+        <br />
+        <img width="100%" src={img} />
+      </ModalBody>
+      <ModalActionRow>
+        <ModalClose asChild>
+          <Button variant="secondary">Cancel</Button>
+        </ModalClose>
+        <Button>Begin</Button>
+      </ModalActionRow>
+    </div>
   ),
 };
 

--- a/src/styles/_variables.scss
+++ b/src/styles/_variables.scss
@@ -30,8 +30,6 @@
   --st-react-dropdown-control-hover-background-color: var(--st-gray-10);
   --st-react-dropdown-control-hover-border: 1px solid var(--st-gray-20);
   --st-react-dropdown-control-focus-box-shadow: 0px 0px 0px 1px #4d90fe;
-  --st-react-dropdown-control-focus-open-box-shadow: 1px -1px 0px 0px #4d90fe,
-    -1px 0px 0px 0px #4d90fe;
   --st-react-dropdown-menu-focus-box-shadow: 0px 1px 0px 0px #4d90fe,
     1px 0px 0px 0px #4d90fe, -1px 0px 0px 0px #4d90fe;
   --st-react-dropdown-placeholder-color: var(--st-gray-50);
@@ -42,7 +40,6 @@
   --st-react-dropdown-menu-list-padding-bottom: calc(var(--st-grid-unit) / 2);
   --st-react-dropdown-menu-list-border-radius: calc(var(--st-grid-unit) / 2);
   --st-react-dropdown-menu-list-box-shadow: 0 2px 3px 0 rgb(34 36 38 / 15%);
-  --st-react-dropdown-menu-list-max-height: 310px;
   --st-react-dropdown-menu-list-background-color: var(--st-white);
   --st-react-dropdown-menu-no-options-label-color: var(--st-gray-50);
   --st-react-dropdown-indicator-padding: 0 var(--st-grid-unit);

--- a/src/styles/components/_Dropdown.scss
+++ b/src/styles/components/_Dropdown.scss
@@ -76,7 +76,6 @@
     border-radius: var(--st-react-dropdown-menu-list-border-radius);
     border-radius: inherit;
     box-shadow: var(--st-react-dropdown-menu-list-box-shadow);
-    max-height: var(--st-react-dropdown-menu-list-max-height) !important;
     background: var(--st-react-dropdown-menu-list-background-color)
   }
 


### PR DESCRIPTION
As I was using the Modal component in an application I discovered that it didn't play nicely with components like popovers and dropdowns with scrolling content as described in this fairly new Radix issue https://github.com/radix-ui/primitives/issues/1159. A resolution was suggested by the issue reporter which was to make the modal contents a child of the modal overlay which seems to do the trick. I don't fully understand the inner workings of these Radix components but I haven't seen any issues with this change yet.

This PR also addresses a small styling issue I discovered with the Dropdown component related to max height. Previously max height of the Dropdown menu was controlled by a CSS variable with an `important!` but it's much better to make use of the `maxMenuHeight` react-select prop on the Dropdown as this will make it much easier to customize the max height on a case by case basis. I did remove the max height style on the menu which means it'll be using the react-select default value which I think should be fine in most cases and if not the user can specify a max height via props.