### PR TITLE
Add modal and alert Content props pass through

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@nasa-jpl/react-stellar",
-  "version": "0.1.5",
+  "version": "0.1.6",
   "description": "The React implementation of the Stellar Design System",
   "main": "dist/index.js",
   "module": "dist/index.es.js",

--- a/src/components/Alert/Alert.tsx
+++ b/src/components/Alert/Alert.tsx
@@ -39,6 +39,7 @@ export type AlertProps = {
   description?: string | React.ReactNode;
   children?: string | React.ReactNode;
   trigger?: React.ReactNode;
+  alertContentProps?: AlertDialog.AlertDialogContentProps;
   className?: string;
 } & AlertDialog.DialogProps;
 
@@ -49,13 +50,14 @@ export const Alert = (props: AlertProps) => {
     children,
     trigger,
     className = "",
+    alertContentProps,
     ...alertProps
   } = props;
 
   return (
     <AlertDialog.Root {...alertProps}>
       <AlertDialog.Overlay className="st-react-modal--overlay" />
-      <AlertContent className={className}>
+      <AlertContent className={className} {...alertContentProps}>
         <div className="st-react-modal--header">
           <div className="st-react-modal--header--title-row">
             <AlertTitle asChild>

--- a/src/components/Modal/Modal.tsx
+++ b/src/components/Modal/Modal.tsx
@@ -73,15 +73,23 @@ export type ModalProps = {
   children?: string | React.ReactNode;
   trigger?: React.ReactNode;
   className?: string;
+  modalContentProps?: DialogPrimitive.DialogContentProps;
 } & DialogPrimitive.DialogProps;
 
 export const Modal = (props: ModalProps) => {
-  const { title, children, trigger, className = "", ...modalProps } = props;
+  const {
+    title,
+    children,
+    trigger,
+    className = "",
+    modalContentProps,
+    ...modalProps
+  } = props;
 
   return (
     <DialogPrimitive.Root {...modalProps}>
       <DialogPrimitive.Overlay className="st-react-modal--overlay">
-        <ModalContent className={className}>
+        <ModalContent className={className} {...modalContentProps}>
           <div className="st-react-modal--header">
             <div className="st-react-modal--header--title-row">
               <ModalTitle asChild>

--- a/src/stories/Alert.stories.tsx
+++ b/src/stories/Alert.stories.tsx
@@ -33,6 +33,37 @@ Controlled.args = {
   ),
 };
 
+export const OverrideContentProps = Template.bind({});
+OverrideContentProps.parameters = { docs: { disable: true } }; // disable docs for this modal since it will always be open and will interfere with doc viewing
+OverrideContentProps.args = {
+  title: "Are you sure?",
+  trigger: (
+    <Button size="large" onClick={() => {}}>
+      Open Alert
+    </Button>
+  ),
+  description:
+    "Escape has been overridden to not automatically close the alert.",
+  onOpenChange: action("open changed"),
+  alertContentProps: {
+    onEscapeKeyDown: (evt) => {
+      evt.preventDefault();
+    },
+  },
+  children: (
+    <>
+      <AlertCancel asChild>
+        <Button variant="secondary" onClick={action("action")}>
+          Cancel
+        </Button>
+      </AlertCancel>
+      <AlertAction asChild>
+        <Button onClick={action("action")}>Delete</Button>
+      </AlertAction>
+    </>
+  ),
+};
+
 export const ReactJSXExample = () => (
   <Alert
     title="Are you sure?"

--- a/src/stories/Modal.stories.tsx
+++ b/src/stories/Modal.stories.tsx
@@ -91,6 +91,42 @@ WithScrollingContent.args = {
   ),
 };
 
+export const OverrideModalContentProps = Template.bind({});
+OverrideModalContentProps.parameters = { docs: { disable: true } }; // disable docs for this modal since it will always be open and will interfere with doc viewing
+OverrideModalContentProps.args = {
+  title: "Modal Title",
+  onOpenChange: action("open changed"),
+  trigger: (
+    <Button size="large" onClick={() => {}}>
+      Open Modal
+    </Button>
+  ),
+  modalContentProps: {
+    onEscapeKeyDown: (evt) => {
+      evt.preventDefault();
+    },
+    onPointerDownOutside: (evt) => {
+      evt.preventDefault();
+    },
+  },
+  children: (
+    <div>
+      <ModalBody>
+        <ModalDescription>
+          Escape and pointer down outside ModalContent events have been overridden to not automatically close the modal.
+        </ModalDescription>
+        <img width="100%" src={img} />
+      </ModalBody>
+      <ModalActionRow>
+        <ModalClose asChild>
+          <Button variant="secondary">Cancel</Button>
+        </ModalClose>
+        <Button>Begin</Button>
+      </ModalActionRow>
+    </div>
+  ),
+};
+
 export const ReactJSXExample = () => (
   <div>
     <Modal

--- a/src/stories/Modal.stories.tsx
+++ b/src/stories/Modal.stories.tsx
@@ -113,7 +113,8 @@ OverrideModalContentProps.args = {
     <div>
       <ModalBody>
         <ModalDescription>
-          Escape and pointer down outside ModalContent events have been overridden to not automatically close the modal.
+          Escape and pointer down outside ModalContent events have been
+          overridden to not automatically close the modal.
         </ModalDescription>
         <img width="100%" src={img} />
       </ModalBody>


### PR DESCRIPTION
While users could construct a modal from scratch using the exported modal (or alert) primitives it would be nice if we allowed passthrough of Modal/Alert Content props for ease of implementing certain common behaviors like preventing the user from closing the Modal/Alert on escape key down or pointer outside events.