### PR TITLE
Navbar fixes

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@nasa-jpl/react-stellar",
-  "version": "1.1.1",
+  "version": "1.1.2",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@nasa-jpl/react-stellar",
-      "version": "1.1.1",
+      "version": "1.1.2",
       "license": "Apache-2.0",
       "dependencies": {
         "@nasa-jpl/stellar": "^1.1.8",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@nasa-jpl/react-stellar",
-  "version": "1.1.1",
+  "version": "1.1.2",
   "description": "The React implementation of the Stellar Design System",
   "main": "dist/cjs/index.js",
   "module": "dist/esm/index.js",

--- a/src/components/Navbar/Navbar.tsx
+++ b/src/components/Navbar/Navbar.tsx
@@ -142,7 +142,7 @@ export const NavbarSpacer = () => (
 );
 
 export type NavbarProps = {
-  children?: React.ReactNode[];
+  children?: React.ReactNode;
   enableMobileMenu?: boolean;
   mobileBreakpoint?: number;
   mobileMenuPosition?: "left" | "right";
@@ -198,10 +198,10 @@ export const Navbar = (props: NavbarProps) => {
   const visibleChildren: React.ReactNode[] = [];
   let mobileMenu;
   ((children as ReactJSXElement[]) || []).forEach((child) => {
-    if (child.type.displayName === NavbarMobileMenu.name) {
+    if (child.type.name === NavbarMobileMenu.name) {
       // Pull out the mobile menu as we will render it separately
       mobileMenu = child;
-    } else if (child.type.displayName === NavbarBreakpoint.name) {
+    } else if (child.type.name === NavbarBreakpoint.name) {
       // Enforce min and max breakpoints
       const childProps = child.props as NavbarBreakpointProps;
       if (


### PR DESCRIPTION
- Fix NavbarBreakpoint children type
- Fix for detection of NavbarMobileMenu, use `name` instead of `displayName`.