### PR TITLE
Slider updates

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@nasa-jpl/react-stellar",
-  "version": "1.1.4",
+  "version": "1.1.5",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@nasa-jpl/react-stellar",
-      "version": "1.1.4",
+      "version": "1.1.5",
       "license": "Apache-2.0",
       "dependencies": {
         "@nasa-jpl/stellar": "^1.1.8",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@nasa-jpl/react-stellar",
-  "version": "1.1.4",
+  "version": "1.1.5",
   "description": "The React implementation of the Stellar Design System",
   "main": "dist/cjs/index.js",
   "module": "dist/esm/index.js",

--- a/src/components/Slider/Slider.stories.tsx
+++ b/src/components/Slider/Slider.stories.tsx
@@ -56,6 +56,16 @@ export const LabelRight: Story = {
   render: Single.render,
 };
 
+export const InputRight: Story = {
+  args: {
+    ...Single.args,
+    label: "Switch label",
+    inputPosition: "right",
+  },
+  decorators: Single.decorators,
+  render: Single.render,
+};
+
 export const WithRangeShown: Story = {
   args: {
     ...Single.args,


### PR DESCRIPTION
- Pass min/max props to Slider
- Make `step` an explicit prop to be more visible in Storybook
- Round range labels to at most 3 decimal places
- Add `inputPosition` prop to control the primary input position