### PR TITLE
Use portal for tooltip

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@nasa-jpl/react-stellar",
-  "version": "1.1.5",
+  "version": "1.1.6",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@nasa-jpl/react-stellar",
-      "version": "1.1.5",
+      "version": "1.1.6",
       "license": "Apache-2.0",
       "dependencies": {
         "@nasa-jpl/stellar": "^1.1.8",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@nasa-jpl/react-stellar",
-  "version": "1.1.5",
+  "version": "1.1.6",
   "description": "The React implementation of the Stellar Design System",
   "main": "dist/cjs/index.js",
   "module": "dist/esm/index.js",

--- a/src/components/Tooltip/Tooltip.tsx
+++ b/src/components/Tooltip/Tooltip.tsx
@@ -49,20 +49,22 @@ export const Tooltip = (props: TooltipProps) => {
       {...otherTooltipProps}
     >
       <TooltipPrimitive.Trigger asChild>{children}</TooltipPrimitive.Trigger>
-      <TooltipPrimitive.Content
-        side="top"
-        align="center"
-        className={contentClass}
-        sideOffset={sideOffset}
-        {...otherContentProps}
-      >
-        {content}
-        <TooltipPrimitive.Arrow
-          width={arrowWidth}
-          height={arrowHeight}
-          className="st-react-tooltip--arrow"
-        />
-      </TooltipPrimitive.Content>
+      <TooltipPrimitive.Portal>
+        <TooltipPrimitive.Content
+          side="top"
+          align="center"
+          className={contentClass}
+          sideOffset={sideOffset}
+          {...otherContentProps}
+        >
+          {content}
+          <TooltipPrimitive.Arrow
+            width={arrowWidth}
+            height={arrowHeight}
+            className="st-react-tooltip--arrow"
+          />
+        </TooltipPrimitive.Content>
+      </TooltipPrimitive.Portal>
     </TooltipPrimitive.Root>
   );
 };


### PR DESCRIPTION
Radix [docs on tooltips](https://www.radix-ui.com/primitives/docs/components/tooltip) now suggested wrapping the content with a Portal. Portal-ing tooltips will help keep them appropriately z-indexed which is currently an issue with our tooltips.